### PR TITLE
Fix symlink attack via predictable temp file path in query_mailer_ovh

### DIFF
--- a/scripts/query_mailer_ovh
+++ b/scripts/query_mailer_ovh
@@ -12,9 +12,10 @@
 version="1.1"
 lastupdated="16 April 2018"
 
-temp_file="/tmp/ovh_hosts.txt"
+temp_file="$(mktemp /tmp/ovh_hosts.XXXXXX)"
+trap 'rm -f "$temp_file"' EXIT
 allowlist_file="/etc/postfix/postscreen_ovh_allowlist.cidr"
-        
+
 ###########################################################################
         
 # This script uses "mail-out.ovh.net" as a working example of a mailhost
@@ -46,7 +47,7 @@ done > $temp_file
 
 printf "Formatting custom allowlist...\n"
 
-grep 'has address' /tmp/ovh_hosts.txt | awk '{print $4 " permit"}' | sort -uV  > $allowlist_file
+grep 'has address' "$temp_file" | awk '{print $4 " permit"}' | sort -uV  > $allowlist_file
 
 # Restart Postfix
 


### PR DESCRIPTION
Replace hardcoded /tmp/ovh_hosts.txt with mktemp to prevent a local attacker from pre-creating a symlink at that path and having the script (running as root) overwrite an arbitrary file. Add a trap to clean up the temp file on exit, and update the hardcoded grep reference to use the variable.