### PR TITLE
Feat/makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,14 @@
 #   make install PREFIX=/usr DESTDIR=/tmp/staging
 #
 # Typical packager invocations:
-#   make install PREFIX=/usr SYSCONFDIR=/etc DESTDIR=%{buildroot}              # RPM
-#   make install PREFIX=/usr SYSCONFDIR=/etc DESTDIR=$(CURDIR)/debian/postallow  # Debian
-#   make install PREFIX=/usr/local DESTDIR=/tmp/stage                         # BSD ports
+#   make install PREFIX=/usr SYSCONFDIR=/etc DESTDIR=%{buildroot}                 # RPM
+#   make install PREFIX=/usr SYSCONFDIR=/etc DESTDIR=$(CURDIR)/debian/postallow   # Debian
+#   make install PREFIX=/usr/local DESTDIR=/tmp/stage COMPRESS_MAN=no            # BSD ports
+#
+# NOTE: 'make install' does not create the postallow system user or the output
+# directory it writes CIDR files to. For manual installs, run contrib/install.sh
+# first. OS packagers should handle user creation in their pre-install hooks
+# (%pre for RPM, preinst for Debian, pkg-install for BSD ports). See README.md.
 
 PREFIX      ?= /usr/local
 DESTDIR     ?=
@@ -26,9 +31,16 @@ RCDIR_FREEBSD   ?= $(PREFIX)/etc/rc.d
 RCDIR_OPENBSD   ?= /etc/rc.d
 RCDIR_NETBSD    ?= /etc/rc.d
 
-# Compression tool for man pages
-GZIP        ?= gzip
-GZIP_FLAGS  ?= -9
+# Man page compression.
+# 'auto' (default): compress on Linux (gzip), leave uncompressed on BSDs.
+#   BSD ports and pkgsrc compress man pages themselves as part of the package
+#   build; pre-compressing breaks their tooling. Pass COMPRESS_MAN=no for BSD.
+# Note: when cross-packaging with DESTDIR on a different host OS (e.g. building
+#   a FreeBSD package on Linux CI), uname returns the BUILD machine's OS.
+#   In that case, set COMPRESS_MAN explicitly rather than relying on 'auto'.
+COMPRESS_MAN ?= auto
+GZIP         ?= gzip
+GZIP_FLAGS   ?= -9
 
 .PHONY: install uninstall help
 
@@ -36,31 +48,36 @@ help:
 	@echo "Targets:  install, uninstall, help"
 	@echo ""
 	@echo "Variables (override on the command line):"
-	@printf "  %-20s script                             [%s]\n" "BINDIR"          "$(BINDIR)"
+	@printf "  %-20s script and tools                   [%s]\n" "BINDIR"          "$(BINDIR)"
 	@printf "  %-20s sample config and allowlist_hosts  [%s]\n" "SYSCONFDIR"      "$(SYSCONFDIR)"
-	@printf "  %-20s yahoo_static_hosts.txt             [%s]\n" "DATADIR"         "$(DATADIR)"
+	@printf "  %-20s static data files                  [%s]\n" "DATADIR"         "$(DATADIR)"
 	@printf "  %-20s man pages                          [%s]\n" "MANDIR"          "$(MANDIR)"
 	@printf "  %-20s documentation                      [%s]\n" "DOCDIR"          "$(DOCDIR)"
 	@printf "  %-20s systemd unit files (Linux)         [%s]\n" "SYSTEMD_UNITDIR" "$(SYSTEMD_UNITDIR)"
 	@printf "  %-20s rc.d script (FreeBSD)              [%s]\n" "RCDIR_FREEBSD"   "$(RCDIR_FREEBSD)"
 	@printf "  %-20s rc.d script (OpenBSD)              [%s]\n" "RCDIR_OPENBSD"   "$(RCDIR_OPENBSD)"
 	@printf "  %-20s rc.d script (NetBSD)               [%s]\n" "RCDIR_NETBSD"    "$(RCDIR_NETBSD)"
+	@printf "  %-20s compress man pages (auto/yes/no)   [%s]\n" "COMPRESS_MAN"    "$(COMPRESS_MAN)"
 	@printf "  %-20s staged install root (packagers)    [%s]\n" "DESTDIR"         "$(DESTDIR)"
 	@echo ""
 	@echo "Init service units are installed automatically based on the detected"
 	@echo "platform (uname -s). The service is NOT enabled automatically;"
 	@echo "that is left to the administrator or package post-install hook."
+	@echo ""
+	@echo "See contrib/install.sh to create the postallow system user and output"
+	@echo "directory before running 'make install' on a live system."
 
 install:
-	# script
+	# --- script and tools ---
 	install -d -m 755 $(DESTDIR)$(BINDIR)
 	install -m 755 postallow $(DESTDIR)$(BINDIR)/postallow
+	install -m 755 scripts/scrape_yahoo $(DESTDIR)$(BINDIR)/scrape_yahoo
 
-	# static data
+	# --- static data ---
 	install -d -m 755 $(DESTDIR)$(DATADIR)
 	install -m 644 yahoo_static_hosts.txt $(DESTDIR)$(DATADIR)/yahoo_static_hosts.txt
 
-	# sample config (do not overwrite an existing live config)
+	# --- sample config (do not overwrite an existing live config) ---
 	install -d -m 755 $(DESTDIR)$(SYSCONFDIR)/postallow
 	if [ ! -f $(DESTDIR)$(SYSCONFDIR)/postallow/postallow.conf ]; then \
 		install -m 644 conf/postallow.conf \
@@ -71,20 +88,30 @@ install:
 			$(DESTDIR)$(SYSCONFDIR)/postallow/allowlist_hosts; \
 	fi
 
-	# man pages
+	# --- man pages ---
 	install -d -m 755 $(DESTDIR)$(MANDIR)/man1
-	$(GZIP) $(GZIP_FLAGS) < man/man1/postallow.1 \
-		> $(DESTDIR)$(MANDIR)/man1/postallow.1.gz
+	install -m 644 man/man1/postallow.1 $(DESTDIR)$(MANDIR)/man1/postallow.1
 	install -d -m 755 $(DESTDIR)$(MANDIR)/man5
-	$(GZIP) $(GZIP_FLAGS) < man/man5/postallow.conf.5 \
-		> $(DESTDIR)$(MANDIR)/man5/postallow.conf.5.gz
+	install -m 644 man/man5/postallow.conf.5 $(DESTDIR)$(MANDIR)/man5/postallow.conf.5
+	@_cm="$(COMPRESS_MAN)"; \
+	if [ "$$_cm" = "auto" ]; then \
+		case "$$(uname -s)" in Linux) _cm=yes ;; *) _cm=no ;; esac; \
+	fi; \
+	if [ "$$_cm" = "yes" ]; then \
+		echo "# man pages: compressing with $(GZIP)"; \
+		$(GZIP) $(GZIP_FLAGS) $(DESTDIR)$(MANDIR)/man1/postallow.1; \
+		$(GZIP) $(GZIP_FLAGS) $(DESTDIR)$(MANDIR)/man5/postallow.conf.5; \
+	fi
 
-	# documentation
+	# --- documentation ---
 	install -d -m 755 $(DESTDIR)$(DOCDIR)
 	install -m 644 README.md  $(DESTDIR)$(DOCDIR)/README.md
 	install -m 644 LICENSE.md $(DESTDIR)$(DOCDIR)/LICENSE.md
+	# query_mailer_ovh is an example script for mailers without SPF records;
+	# installed as documentation rather than an executable tool.
+	install -m 644 scripts/query_mailer_ovh $(DESTDIR)$(DOCDIR)/query_mailer_ovh.example
 
-	# init service units – platform detected at install time
+	# --- init service units – platform detected at install time ---
 	@case "$$(uname -s)" in \
 	Linux) \
 		echo "# init (systemd)"; \
@@ -128,17 +155,31 @@ install:
 
 uninstall:
 	rm -f  $(DESTDIR)$(BINDIR)/postallow
+	rm -f  $(DESTDIR)$(BINDIR)/scrape_yahoo
 	rm -f  $(DESTDIR)$(DATADIR)/yahoo_static_hosts.txt
 	rm -df $(DESTDIR)$(DATADIR)
+	rm -f  $(DESTDIR)$(MANDIR)/man1/postallow.1
 	rm -f  $(DESTDIR)$(MANDIR)/man1/postallow.1.gz
+	rm -f  $(DESTDIR)$(MANDIR)/man5/postallow.conf.5
 	rm -f  $(DESTDIR)$(MANDIR)/man5/postallow.conf.5.gz
 	rm -f  $(DESTDIR)$(DOCDIR)/README.md
 	rm -f  $(DESTDIR)$(DOCDIR)/LICENSE.md
+	rm -f  $(DESTDIR)$(DOCDIR)/query_mailer_ovh.example
 	rm -df $(DESTDIR)$(DOCDIR)
-	rm -f  $(DESTDIR)$(SYSTEMD_UNITDIR)/postallow.service
-	rm -f  $(DESTDIR)$(SYSTEMD_UNITDIR)/postallow.timer
-	rm -f  $(DESTDIR)$(RCDIR_FREEBSD)/postallow
-	rm -f  $(DESTDIR)$(RCDIR_OPENBSD)/postallow
-	rm -f  $(DESTDIR)$(RCDIR_NETBSD)/postallow
+	@case "$$(uname -s)" in \
+	Linux) \
+		rm -f $(DESTDIR)$(SYSTEMD_UNITDIR)/postallow.service; \
+		rm -f $(DESTDIR)$(SYSTEMD_UNITDIR)/postallow.timer; \
+		;; \
+	FreeBSD) \
+		rm -f $(DESTDIR)$(RCDIR_FREEBSD)/postallow; \
+		;; \
+	OpenBSD) \
+		rm -f $(DESTDIR)$(RCDIR_OPENBSD)/postallow; \
+		;; \
+	NetBSD) \
+		rm -f $(DESTDIR)$(RCDIR_NETBSD)/postallow; \
+		;; \
+	esac
 	@echo "Note: $(SYSCONFDIR)/postallow/ was not removed (may contain live config)."
 	@echo "Note: disable and stop the service before uninstalling if it was enabled."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,144 @@
+# Postallow – install / uninstall
+#
+# Override variables on the command line, e.g.:
+#   make install PREFIX=/usr
+#   make install PREFIX=/usr DESTDIR=/tmp/staging
+#
+# Typical packager invocations:
+#   make install PREFIX=/usr SYSCONFDIR=/etc DESTDIR=%{buildroot}              # RPM
+#   make install PREFIX=/usr SYSCONFDIR=/etc DESTDIR=$(CURDIR)/debian/postallow  # Debian
+#   make install PREFIX=/usr/local DESTDIR=/tmp/stage                         # BSD ports
+
+PREFIX      ?= /usr/local
+DESTDIR     ?=
+BINDIR      ?= $(PREFIX)/bin
+SYSCONFDIR  ?= $(PREFIX)/etc
+DATADIR     ?= $(PREFIX)/share/postallow
+MANDIR      ?= $(PREFIX)/share/man
+DOCDIR      ?= $(PREFIX)/share/doc/postallow
+
+# Init system unit directories – override if your layout differs.
+# On Linux the systemd units go to the vendor preset directory (not /etc).
+# On FreeBSD/NetBSD ports install rc.d scripts under PREFIX/etc/rc.d.
+# On OpenBSD they go under /etc/rc.d regardless of PREFIX.
+SYSTEMD_UNITDIR ?= $(PREFIX)/lib/systemd/system
+RCDIR_FREEBSD   ?= $(PREFIX)/etc/rc.d
+RCDIR_OPENBSD   ?= /etc/rc.d
+RCDIR_NETBSD    ?= /etc/rc.d
+
+# Compression tool for man pages
+GZIP        ?= gzip
+GZIP_FLAGS  ?= -9
+
+.PHONY: install uninstall help
+
+help:
+	@echo "Targets:  install, uninstall, help"
+	@echo ""
+	@echo "Variables (override on the command line):"
+	@printf "  %-20s script                             [%s]\n" "BINDIR"          "$(BINDIR)"
+	@printf "  %-20s sample config and allowlist_hosts  [%s]\n" "SYSCONFDIR"      "$(SYSCONFDIR)"
+	@printf "  %-20s yahoo_static_hosts.txt             [%s]\n" "DATADIR"         "$(DATADIR)"
+	@printf "  %-20s man pages                          [%s]\n" "MANDIR"          "$(MANDIR)"
+	@printf "  %-20s documentation                      [%s]\n" "DOCDIR"          "$(DOCDIR)"
+	@printf "  %-20s systemd unit files (Linux)         [%s]\n" "SYSTEMD_UNITDIR" "$(SYSTEMD_UNITDIR)"
+	@printf "  %-20s rc.d script (FreeBSD)              [%s]\n" "RCDIR_FREEBSD"   "$(RCDIR_FREEBSD)"
+	@printf "  %-20s rc.d script (OpenBSD)              [%s]\n" "RCDIR_OPENBSD"   "$(RCDIR_OPENBSD)"
+	@printf "  %-20s rc.d script (NetBSD)               [%s]\n" "RCDIR_NETBSD"    "$(RCDIR_NETBSD)"
+	@printf "  %-20s staged install root (packagers)    [%s]\n" "DESTDIR"         "$(DESTDIR)"
+	@echo ""
+	@echo "Init service units are installed automatically based on the detected"
+	@echo "platform (uname -s). The service is NOT enabled automatically;"
+	@echo "that is left to the administrator or package post-install hook."
+
+install:
+	# script
+	install -d -m 755 $(DESTDIR)$(BINDIR)
+	install -m 755 postallow $(DESTDIR)$(BINDIR)/postallow
+
+	# static data
+	install -d -m 755 $(DESTDIR)$(DATADIR)
+	install -m 644 yahoo_static_hosts.txt $(DESTDIR)$(DATADIR)/yahoo_static_hosts.txt
+
+	# sample config (do not overwrite an existing live config)
+	install -d -m 755 $(DESTDIR)$(SYSCONFDIR)/postallow
+	if [ ! -f $(DESTDIR)$(SYSCONFDIR)/postallow/postallow.conf ]; then \
+		install -m 644 conf/postallow.conf \
+			$(DESTDIR)$(SYSCONFDIR)/postallow/postallow.conf; \
+	fi
+	if [ ! -f $(DESTDIR)$(SYSCONFDIR)/postallow/allowlist_hosts ]; then \
+		install -m 644 conf/allowlist_hosts \
+			$(DESTDIR)$(SYSCONFDIR)/postallow/allowlist_hosts; \
+	fi
+
+	# man pages
+	install -d -m 755 $(DESTDIR)$(MANDIR)/man1
+	$(GZIP) $(GZIP_FLAGS) < man/man1/postallow.1 \
+		> $(DESTDIR)$(MANDIR)/man1/postallow.1.gz
+	install -d -m 755 $(DESTDIR)$(MANDIR)/man5
+	$(GZIP) $(GZIP_FLAGS) < man/man5/postallow.conf.5 \
+		> $(DESTDIR)$(MANDIR)/man5/postallow.conf.5.gz
+
+	# documentation
+	install -d -m 755 $(DESTDIR)$(DOCDIR)
+	install -m 644 README.md  $(DESTDIR)$(DOCDIR)/README.md
+	install -m 644 LICENSE.md $(DESTDIR)$(DOCDIR)/LICENSE.md
+
+	# init service units – platform detected at install time
+	@case "$$(uname -s)" in \
+	Linux) \
+		echo "# init (systemd)"; \
+		install -d -m 755 $(DESTDIR)$(SYSTEMD_UNITDIR); \
+		install -m 644 contrib/systemd/postallow.service \
+			$(DESTDIR)$(SYSTEMD_UNITDIR)/postallow.service; \
+		install -m 644 contrib/systemd/postallow.timer \
+			$(DESTDIR)$(SYSTEMD_UNITDIR)/postallow.timer; \
+		echo "  installed: $(SYSTEMD_UNITDIR)/postallow.{service,timer}"; \
+		echo "  Run 'systemctl daemon-reload && systemctl enable --now postallow.timer' to activate."; \
+		;; \
+	FreeBSD) \
+		echo "# init (rc.d, FreeBSD)"; \
+		install -d -m 755 $(DESTDIR)$(RCDIR_FREEBSD); \
+		install -m 555 contrib/freebsd/postallow.rc \
+			$(DESTDIR)$(RCDIR_FREEBSD)/postallow; \
+		echo "  installed: $(RCDIR_FREEBSD)/postallow"; \
+		echo "  Add 'postallow_enable=YES' to /etc/rc.conf to activate."; \
+		;; \
+	OpenBSD) \
+		echo "# init (rc.d, OpenBSD)"; \
+		install -d -m 755 $(DESTDIR)$(RCDIR_OPENBSD); \
+		install -m 555 contrib/freebsd/postallow.rc \
+			$(DESTDIR)$(RCDIR_OPENBSD)/postallow; \
+		echo "  installed: $(RCDIR_OPENBSD)/postallow"; \
+		echo "  Run 'rcctl enable postallow' to activate."; \
+		;; \
+	NetBSD) \
+		echo "# init (rc.d, NetBSD)"; \
+		install -d -m 755 $(DESTDIR)$(RCDIR_NETBSD); \
+		install -m 555 contrib/freebsd/postallow.rc \
+			$(DESTDIR)$(RCDIR_NETBSD)/postallow; \
+		echo "  installed: $(RCDIR_NETBSD)/postallow"; \
+		echo "  Add 'postallow=YES' to /etc/rc.conf to activate."; \
+		;; \
+	*) \
+		echo "# init: unsupported platform $$(uname -s), skipping service unit install."; \
+		echo "  See contrib/ for available units and README.md for instructions."; \
+		;; \
+	esac
+
+uninstall:
+	rm -f  $(DESTDIR)$(BINDIR)/postallow
+	rm -f  $(DESTDIR)$(DATADIR)/yahoo_static_hosts.txt
+	rm -df $(DESTDIR)$(DATADIR)
+	rm -f  $(DESTDIR)$(MANDIR)/man1/postallow.1.gz
+	rm -f  $(DESTDIR)$(MANDIR)/man5/postallow.conf.5.gz
+	rm -f  $(DESTDIR)$(DOCDIR)/README.md
+	rm -f  $(DESTDIR)$(DOCDIR)/LICENSE.md
+	rm -df $(DESTDIR)$(DOCDIR)
+	rm -f  $(DESTDIR)$(SYSTEMD_UNITDIR)/postallow.service
+	rm -f  $(DESTDIR)$(SYSTEMD_UNITDIR)/postallow.timer
+	rm -f  $(DESTDIR)$(RCDIR_FREEBSD)/postallow
+	rm -f  $(DESTDIR)$(RCDIR_OPENBSD)/postallow
+	rm -f  $(DESTDIR)$(RCDIR_NETBSD)/postallow
+	@echo "Note: $(SYSCONFDIR)/postallow/ was not removed (may contain live config)."
+	@echo "Note: disable and stop the service before uninstalling if it was enabled."

--- a/README.md
+++ b/README.md
@@ -61,15 +61,28 @@ Create the directory owned by `postallow` with mode 755:
 
     install -d -o postallow -m 755 /var/lib/postallow   # adjust path for your platform
 
-## 2. Install and configure Postallow
+## 2. Install Postallow
 
-1. Clone or copy the Postallow repo to `/usr/local/bin/` (or wherever you prefer)
-2. Make sure you have [SPF-Tools](https://github.com/spf-tools/spf-tools) on your system
-3. Copy `postallow.conf` to the appropriate location for your platform and edit it:
-   - Linux: `/etc/postallow/postallow.conf`
-   - BSD: `/usr/local/etc/postallow/postallow.conf`
-4. Set `postfixpath` to the output directory created above (see the comments in `postallow.conf` for platform variants)
-5. Add any custom hosts to `allowlist_hosts`
+    make install
+
+The default prefix is `/usr/local`. Common overrides:
+
+    make install PREFIX=/usr SYSCONFDIR=/etc          # Linux, installing system-wide
+    make install PREFIX=/usr/local                    # BSDs, ports default
+
+Run `make help` to see all available variables and their defaults.
+
+`make install` places the init service unit for your platform (systemd on Linux, rc.d on BSDs) in the appropriate directory but does **not** enable or start it — see step 4.
+
+## 3. Configure Postallow
+
+Edit the configuration file installed at `SYSCONFDIR/postallow/postallow.conf` (e.g. `/etc/postallow/postallow.conf` or `/usr/local/etc/postallow/postallow.conf`):
+
+1. Set `postfixpath` to the output directory created in step 1
+2. Verify `spftoolspath` points to your SPF-Tools installation
+3. Add any custom domains to `allowlist_hosts`
+
+See `postallow.conf(5)` for a description of all options.
 
 The script searches for its config file in the following locations, in order:
 
@@ -83,7 +96,7 @@ You can always override by passing the path explicitly:
 
     /usr/local/bin/postallow /path/to/config-file
 
-## 3. Configure Postfix
+## 4. Configure Postfix
 
 Point Postfix's `postscreen_access_list` directly at the output directory. There is no need for the files to live under `/etc/postfix/` — Postfix will read them from wherever they are, as long as the `postfix` user can read them. The generated files are world-readable (mode 644).
 
@@ -95,27 +108,20 @@ Point Postfix's `postscreen_access_list` directly at the output directory. There
 
 Adjust the paths above to match the `postfixpath` you configured.
 
-## 4. Set up the init service
+## 5. Enable the init service
 
-Postallow generates the CIDR files but does not reload Postfix itself. The init service takes care of that, running `postfix reload` with the appropriate privileges after each run.
+`make install` installs the service unit for your platform but does not activate it.
 
 **systemd (most Linux distributions):**
 
-    cp contrib/systemd/postallow.service /etc/systemd/system/
-    cp contrib/systemd/postallow.timer   /etc/systemd/system/
     systemctl daemon-reload
     systemctl enable --now postallow.timer
-
-The service unit runs Postallow as the `postallow` user and reloads Postfix as root via `ExecStartPost=+`. Check that the path to `postfix` in `postallow.service` matches your system (typically `/usr/sbin/postfix`, but adjust if needed).
 
 To run immediately:
 
     systemctl start postallow.service
 
 **FreeBSD (rc.d):**
-
-    cp contrib/freebsd/postallow.rc /usr/local/etc/rc.d/postallow
-    chmod 555 /usr/local/etc/rc.d/postallow
 
 Enable in `/etc/rc.conf`:
 
@@ -148,7 +154,7 @@ It is still possible to update the list of known Yahoo! outbound IP addresses fr
 *(Please read more about Yahoo! hosts below)*
 
 # Options
-Options for Postallow are located in the ```postallow.conf``` file. See the config file search order under **Install and configure Postallow** above for where to place it on your platform.
+Options for Postallow are located in the ```postallow.conf``` file. See the config file search order under **Configure Postallow** above for where to place it on your platform.
 
 ## Custom Hosts
 By default, Postallow includes a number of well-known (and presumably trustworthy) mailers in five categories:


### PR DESCRIPTION
- New Makefile with install, uninstall, and help targets
- Supports PREFIX, DESTDIR, SYSCONFDIR, DATADIR, MANDIR, DOCDIR overrides — suitable for packagers (RPM, Debian, BSD ports)
- Platform detection at install time: installs systemd units on Linux, rc.d scripts on FreeBSD/OpenBSD/NetBSD
- README.md updated: install instructions now use make install; steps renumbered; manual cp of service units removed

Makefile: add COMPRESS_MAN, install scrape_yahoo and query_mailer_ovh                                                                                                                      
- COMPRESS_MAN variable (default auto): gzip man pages on Linux, skip on BSDs (whose port tooling compresses them independently)
- scrape_yahoo installed to BINDIR as an executable tool
- query_mailer_ovh installed to DOCDIR as a .example file (it's a reference script, not a general tool)                    