### PR TITLE
fix: use kill -0 for process existence check in show_dots

### DIFF
--- a/postallow
+++ b/postallow
@@ -191,7 +191,7 @@ query_yahoo_host() {
 
 # Create progress dots function
 show_dots() {
-	while ps "$1" >/dev/null; do
+	while kill -0 "$1" 2>/dev/null; do
 		printf "."
 		sleep 1
 	done


### PR DESCRIPTION
ps(1) with a PID argument is not supported by busybox ps (used on Alpine Linux and other minimal environments), causing show_dots to error or behave incorrectly.

Replace with `kill -0 $PID` which is POSIX-compliant and works universally across busybox, GNU coreutils, macOS, and BSD. kill -0 sends no signal; it merely checks whether the process exists and is signalable by the caller — safe to use since we own the background process we spawned.

Spotted via stevejenkins/postwhite#50 which worked around the same issue using /proc/$PID, a Linux-only approach. kill -0 is strictly more portable.