### PR TITLE
rpm: support openSUSE shadow package name

### DIFF
--- a/rpm/postallow.spec
+++ b/rpm/postallow.spec
@@ -16,7 +16,7 @@ BuildRequires:  systemd-rpm-macros
 Requires:       postfix
 Requires:       spf-tools
 Requires:       route-summarization
-Requires(pre):  shadow-utils
+Requires(pre):  %{?suse_version:shadow}%{!?suse_version:shadow-utils}
 
 %description
 Postallow generates CIDR allowlists (and optionally blocklists) for Postfix's


### PR DESCRIPTION
On openSUSE the user/group management package is `shadow`, not `shadow-utils`. Use RPM inline conditional on `suse_version` to select the right name per platform.