### PR TITLE
ci: remove dispatch steps, point ci to upstream spf-tools, update README for COPR

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -40,14 +40,3 @@ jobs:
         with:
           files: dist/*.deb
 
-      - name: Dispatch to apt repo
-        uses: peter-evans/repository-dispatch@v4
-        with:
-          token: ${{ secrets.REPO_DISPATCH_TOKEN }}
-          repository: edmundlod/apt
-          event-type: package-built
-          client-payload: >-
-            {
-              "deb_url": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ steps.deb.outputs.filename }}",
-              "package": "${{ steps.deb.outputs.filename }}"
-            }

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -55,14 +55,3 @@ jobs:
         with:
           files: dist/*.rpm
 
-      - name: Dispatch to rpm repo
-        uses: peter-evans/repository-dispatch@v4
-        with:
-          token: ${{ secrets.REPO_DISPATCH_TOKEN }}
-          repository: edmundlod/rpm
-          event-type: package-built
-          client-payload: >-
-            {
-              "rpm_url": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ steps.rpm.outputs.filename }}",
-              "package": "${{ steps.rpm.outputs.filename }}"
-            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install spf-tools
         run: |
           sudo git clone --depth=1 \
-            https://github.com/edmundlod/spf-tools \
+            https://github.com/spf-tools/spf-tools \
             /usr/local/bin/spf-tools
           sudo chmod +x /usr/local/bin/spf-tools/*.sh
  
@@ -154,7 +154,7 @@ jobs:
       - name: Install spf-tools
         run: |
           git clone --depth=1 \
-            https://github.com/edmundlod/spf-tools \
+            https://github.com/spf-tools/spf-tools \
             /usr/local/bin/spf-tools
           chmod +x /usr/local/bin/spf-tools/*.sh
 
@@ -246,7 +246,7 @@ jobs:
       - name: Install spf-tools
         run: |
           git clone --depth=1 \
-            https://github.com/edmundlod/spf-tools \
+            https://github.com/spf-tools/spf-tools \
             /usr/local/bin/spf-tools
           chmod +x /usr/local/bin/spf-tools/*.sh
 
@@ -334,7 +334,7 @@ jobs:
       - name: Install spf-tools
         run: |
           git clone --depth=1 \
-            https://github.com/edmundlod/spf-tools \
+            https://github.com/spf-tools/spf-tools \
             /usr/local/bin/spf-tools
           chmod +x /usr/local/bin/spf-tools/*.sh
 
@@ -440,7 +440,7 @@ jobs:
             
             # --- Install spf-tools ---
             git clone --depth=1 \
-              https://github.com/edmundlod/spf-tools \
+              https://github.com/spf-tools/spf-tools \
               /usr/local/bin/spf-tools
             chmod +x /usr/local/bin/spf-tools/*.sh
 

--- a/README.md
+++ b/README.md
@@ -59,16 +59,14 @@ sudo apt install postallow
 
 Then continue with [Configure Postallow](#configure-postallow).
 
-## via dnf (AlmaLinux 10 / RHEL 10)
+## via dnf (AlmaLinux 10 / RHEL 10 / Fedora)
 
-The RPM repository handles all dependencies and user creation automatically.
-EPEL must be enabled for the `perl-Net-CIDR-Lite` dependency:
+Postallow is available via COPR. EPEL must be enabled on RHEL-based systems
+for the `perl-Net-CIDR-Lite` dependency:
 
 ```bash
-sudo dnf install epel-release
-sudo rpm --import https://edmundlod.github.io/rpm/key.asc
-sudo curl -fsSL https://edmundlod.github.io/rpm/edmundlod.repo \
-  -o /etc/yum.repos.d/edmundlod.repo
+sudo dnf install epel-release   # RHEL/AlmaLinux/Rocky only, skip on Fedora
+sudo dnf copr enable edmundlod/postallow
 sudo dnf install postallow
 ```
 


### PR DESCRIPTION
- Remove `REPO_DISPATCH_TOKEN` dispatch steps from `build-deb.yml` and `build-rpm.yml` — apt and rpm repos will poll upstream releases instead
- Update spf-tools clone URL in `ci.yml` from fork to `spf-tools/spf-tools` upstream (×5)
- Update README RPM install section to use COPR instead of personal rpm repo

Note: README change should not be merged until COPR is tested and working.