### PR TITLE
fix: accept bare IPv6 host addresses in verify.sh

### DIFF
--- a/ci/verify.sh
+++ b/ci/verify.sh
@@ -73,7 +73,9 @@ invalid=$(grep -v '^\(#\|[[:space:]]*$\)' "$CIDR_FILE" \
             # IPv6 with mandatory prefix length
             m{^[0-9a-fA-F:]+:[0-9a-fA-F]*/\d{1,3}$} ||
             # IPv6 ::/0 style (starts with ::)
-            m{^::/\d{1,3}$}
+            m{^::/\d{1,3}$} ||
+            # bare IPv6 host (no prefix — postallow strips /128 like /32 for IPv4)
+            m{^[0-9a-fA-F:]+:[0-9a-fA-F]*$}
         ) { print "$_\n" }
     ')
  


### PR DESCRIPTION
Postallow outputs bare IPv6 host addresses without `/128`, the same way it strips `/32` from IPv4 hosts. The verifier accepted bare IPv4 but incorrectly rejected bare IPv6, causing CI failures on all platforms.