### PR TITLE
feat: delegate CIDR normalization to spf-tools normalize.sh pre-aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,11 +227,9 @@ The ```yahoo_static_hosts.txt``` file can be periodically updated by running the
 To enable blocklisting, set ```enable_blocklist=yes``` and then list blocklisted hosts in ```blocklist_hosts```. Please refer to the blocklisting warning above. Blocklisting is not the primary purpose of Postallow, and most users will never need to turn it on.
 
 ## Invalid hosts
-You can also choose how to handle malformed or invalid CIDR ranges that appear in the mailers' SPF records (which happens more often than it should). The options are:
+Some mailers publish SPF records containing invalid CIDR ranges — network addresses with non-null host bits (e.g. `192.168.1.5/24` instead of `192.168.1.0/24`). Postallow corrects these before aggregation using `normalize.sh` from spf-tools.
 
-* **remove** - the default action, it removes the invalid CIDR range so it doesn't appear in the allowlist.
-* **keep** - this keeps the invalid CIDR range in the allowlist. Postfix will log a warning about ```non-null host address bits```, suggest the closest valid range with a matching prefix length, and harmlessly ignore the rule. Useful only if you want to see which mailers are less than careful about their SPF records.
-* **fix** - this option will change the invalid CIDR to the closest valid range (the same one suggested by Postfix, in fact) and include the corrected CIDR range in the allowlist.
+The default behaviour (`invalid_cidr=fix`) corrects the network address to the proper network — the same result Postfix would derive internally anyway, so no legitimate senders are lost. Set `invalid_cidr=remove` in `postallow.conf` to instead drop the range entirely, which was the original Postwhite and early Postallow behaviour.
 
 Other options in ```postallow.conf``` include changing the filenames for your allowlist & blocklist, Postfix path, and SPF-Tools path.
 

--- a/conf/postallow.conf.in
+++ b/conf/postallow.conf.in
@@ -24,8 +24,14 @@ output_dir=@OUTPUTDIR@
 # Include additional Yahoo/Verizon/AOL outbound IPs scraped from
 # senders.yahooinc.com (on top of those already in Yahoo's SPF records).
 # Run scrape_yahoo periodically to keep the list fresh.
-include_yahoo="no"
+include_yahoo=no
 
 # Use a blocklist as well?
 # List domains to block in the blocklist_hosts section of allowlist_hosts.
 enable_blocklist=no
+
+# How to handle invalid IPv4 CIDR ranges (non-null host bits) in SPF records.
+# fix (default): correct the network address to the proper network — the same
+#   result Postfix would derive internally from the invalid range anyway.
+# remove: drop the range entirely (original Postwhite/Postallow behaviour).
+invalid_cidr=fix

--- a/man/man5/postallow.conf.5
+++ b/man/man5/postallow.conf.5
@@ -101,6 +101,16 @@ variable in the
 file.
 Default:
 .IR no .
+.TP
+.BR invalid_cidr = fix | remove
+How to handle invalid IPv4 CIDR ranges (non-null host bits) found in SPF records.
+.B fix
+corrects the network address to the proper network prefix — the same result
+Postfix would derive internally from the invalid range.
+.B remove
+drops the range entirely; this was the original Postwhite and early Postallow behaviour.
+Default:
+.IR fix .
 .
 .SH HOST LIST FILE
 The file pointed to by

--- a/postallow
+++ b/postallow
@@ -76,6 +76,7 @@ printf "\nReading options from %s...\n" "$config_file"
 
 # Defaults for settings removed from conf in v4.2, and backward compat rename
 output_dir=${output_dir:-${postfixpath:-/var/lib/postallow}}
+invalid_cidr=${invalid_cidr:-fix}
 allowlist=${allowlist:-postscreen_spf_allowlist.cidr}
 blocklist=${blocklist:-postscreen_spf_blocklist.cidr}
 if [ -z "${yahoo_static_hosts:-}" ]; then
@@ -138,61 +139,6 @@ for p in $tmpPrefix; do
 	done
 done
 
-# Create IPv4 normalize function
-ip2int() {
-	for i in 1 2 3 4 5; do
-		eval ip2int_${i}="$(echo "$1" | cut -s -d. -f$i)"
-	done
-	ip2int_valid_range="$((ip2int_1 | ip2int_2 | ip2int_3 | ip2int_4))"
-	[ -z "$ip2int_5" ] && [ -n "$ip2int_1" ] && [ -n "$ip2int_2" ] && [ -n "$ip2int_3" ] && [ -n "$ip2int_4" ] && [ "$ip2int_valid_range" -ge 0 ] && [ "$ip2int_valid_range" -le 255 ] &&
-		printf "%d" "$(((((((ip2int_1 << 8) | ip2int_2) << 8) | ip2int_3) << 8) | ip2int_4))"
-}
-
-int2ip() {
-	int2ip_ui32="$1"; shift
-	int2ip_ip=""
-	[ -n "$int2ip_ui32" ] && [ "$int2ip_ui32" -ge 0 ] && [ "$int2ip_ui32" -le 4294967295 ] && for n in 1 2 3 4; do
-		int2ip_ip="$((int2ip_ui32 & 0xff))${int2ip_ip:+.}$int2ip_ip"
-		int2ip_ui32="$((int2ip_ui32 >> 8))"
-	done
-	printf "%s" "${int2ip_ip}"
-}
-
-network_v4() {
-	network_v4_ia="$(echo "$1" | cut -d/ -f1)"
-	network_v4_netmask="$(echo "$1" | cut -d/ -f2-)"
-	if [ -n "$network_v4_netmask" ] && [ "$network_v4_netmask" -ge 0 ] && [ "$network_v4_netmask" -le 32 ]; then
-		network_v4_addr="$(ip2int $network_v4_ia)"
-		network_v4_mask="$((0xffffffff << (32 - network_v4_netmask)))"
-		if [ "$network_v4_netmask" -eq 32 ]; then
-			printf "%s" $(int2ip $((network_v4_addr & network_v4_mask)))
-		else
-			printf "%s/%s" "$(int2ip $((network_v4_addr & network_v4_mask)))" "$network_v4_netmask"
-		fi
-	fi
-}
-
-network_v6() {
-	printf "%s" "$1"
-}
-
-normalize_ip() {
-	# split by ":"
-	normalize_ip_type="$( echo $1 | cut -s -d\: -f1)"
-	normalize_ip_value="$( echo $1 | cut -s -d\: -f2-)"
-	normalize_ip_IP=""
-	if [ x"${normalize_ip_type}" = x"ip4" ] ; then
-		# check if is a CIDR
-		if expr "x${normalize_ip_value}" : "x.*/[0-9]*" > /dev/null; then
-			normalize_ip_IP="$(network_v4 "${normalize_ip_value}")"
-		else
-			normalize_ip_IP="$(network_v4 "${normalize_ip_value}/32")"
-		fi
-	elif [ x"${normalize_ip_type}" = x"ip6" ]; then
-		normalize_ip_IP="$(network_v6 "${normalize_ip_value}")"
-	fi
-	printf "%s" "$normalize_ip_IP"
-}
 
 # Create host query function
 query_host() {
@@ -217,42 +163,16 @@ show_dots() {
 	printf "\n"
 }
 
-# Fix mode
-fix_invalid_ip() {
-	fix_invalid_ip_iptype="$( echo "$1" | cut -d\: -f1 )"
-	fix_invalid_ip_ip="$(normalize_ip "$1")"
-	if [ -n "$fix_invalid_ip_ip" ]; then
-		if [ x"$fix_invalid_ip_iptype" = x"ip4" ]; then
-			printf "$(eval printf "%s" "\${${2}_line_v4}")" "$fix_invalid_ip_ip"
-		elif [ x"$fix_invalid_ip_iptype" = x"ip6" ] ; then
-			printf "$(eval printf "%s" "\${${2}_line_v6}")" "$fix_invalid_ip_ip"
-		fi
-	fi
-}
-
-# Remove mode
-remove_invalid_ip() {
-	remove_invalid_ip_iptype="$( echo "$1" | cut -d\: -f1 )"
-	remove_invalid_ip_origip="$( echo "$1" | cut -d\: -f2- )"
-	remove_invalid_ip_ip="$(normalize_ip "$1")"
-	if [ x"$remove_invalid_ip_origip" = x"$remove_invalid_ip_ip" ]; then
-		if [ x"$remove_invalid_ip_iptype" = x"ip4" ]; then
-			printf "$(eval printf "%s" "\${${2}_line_v4}")" "$remove_invalid_ip_ip"
-		elif [ x"$remove_invalid_ip_iptype" = x"ip6" ] ; then
-			printf "$(eval printf "%s" "\${${2}_line_v6}")" "$remove_invalid_ip_ip"
-		fi
-	fi
-}
-
-# Keep mode
-keep_invalid_ip() {
-	keep_invalid_ip_iptype="$( echo "$1" | cut -d\: -f1 )"
-	keep_invalid_ip_ip="$( echo "$1" | cut -d\: -f2- )"
-	if [ -n "$keep_invalid_ip_ip" ]; then
-		if [ x"$keep_invalid_ip_iptype" = x"ip4" ]; then
-			printf "$(eval printf "%s" "\${${2}_line_v4}")" "$keep_invalid_ip_ip"
-		elif [ x"$keep_invalid_ip_iptype" = x"ip6" ] ; then
-			printf "$(eval printf "%s" "\${${2}_line_v6}")" "$keep_invalid_ip_ip"
+# Format an already-normalized ip4:/ip6: entry for the output file.
+# Invalid CIDRs are handled upstream by normalize.sh before aggregation.
+format_ip() {
+	format_ip_iptype="$( echo "$1" | cut -d\: -f1 )"
+	format_ip_ip="$( echo "$1" | cut -d\: -f2- )"
+	if [ -n "$format_ip_ip" ]; then
+		if [ x"$format_ip_iptype" = x"ip4" ]; then
+			printf "$(eval printf "%s" "\${${2}_line_v4}")" "$format_ip_ip"
+		elif [ x"$format_ip_iptype" = x"ip6" ] ; then
+			printf "$(eval printf "%s" "\${${2}_line_v6}")" "$format_ip_ip"
 		fi
 	fi
 }
@@ -311,28 +231,33 @@ if [ x"$enable_blocklist" = x"yes" ] ; then
 	done
 fi
 
+case "${invalid_cidr}" in
+	remove) _norm_flag="-i" ;;
+	*)      _norm_flag="" ;;
+esac
+
 printf "\nCIDR and Host summarization...\n"
-# the depends on https://github.com/nabbi/route-summarization with symlink in system PATH
-# invalid hosts are also screened and removed
-sed '/\./s/\/32//g' "${tmp1}" | sort -u | ${aggregateCIDR} --quiet --spf > "${tmp2}" &
+# normalize.sh fixes invalid IPv4 CIDRs (non-null host bits) before aggregation;
+# aggregateCIDR.pl is from nabbi/route-summarization, packaged at edmundlod/route-summarization
+sed '/\./s/\/32//g' "${tmp1}" | "${spftoolspath}"/normalize.sh ${_norm_flag} | sort -u | ${aggregateCIDR} --quiet --spf > "${tmp2}" &
 show_dots "$!"
 
 if [ x"$enable_blocklist" = x"yes" ] ; then
-        cat "${blocktmp1}" | sort -u | ${aggregateCIDR} --quiet --spf > "${blocktmp2}" &
+        cat "${blocktmp1}" | "${spftoolspath}"/normalize.sh ${_norm_flag} | sort -u | ${aggregateCIDR} --quiet --spf > "${blocktmp2}" &
         show_dots "$!"
 fi
 
 #Format the lists
 printf "\nFormatting allowlist IPv4 CIDRs...\n"
 cat "${tmp2}" | while read ip; do
-keep_invalid_ip "$ip" "permit"
+format_ip "$ip" "permit"
 done >> "${tmp3}" &
 show_dots "$!"
 
 if [ x"$enable_blocklist" = x"yes" ] ; then
 	printf "\nFormatting blocklist IPv4 CIDRs...\n"
 	cat "${blocktmp2}" | while read ip; do
-		keep_invalid_ip "$ip" "reject"
+		format_ip "$ip" "reject"
 	done >> "${blocktmp3}" &
 	show_dots "$!"
 fi


### PR DESCRIPTION
## Summary

- Replaces the internal `ip2int`/`int2ip`/`network_v4`/`network_v6`/`normalize_ip` functions and the `fix`/`remove`/`keep_invalid_ip` trio with a call to `normalize.sh` from spf-tools, inserted into the pipeline before `aggregateCIDR.pl`
- Invalid IPv4 CIDRs (non-null host bits) are now corrected before aggregation, so the aggregator sees clean data
- Adds `invalid_cidr` config option (`fix` default / `remove` for original Postwhite behaviour)
- Removes dead code; the new `format_ip` function handles output formatting only

## Behaviour change

The previous code was hardcoded to `keep` invalid CIDRs (passing them through uncorrected). The new default (`fix`) corrects the network address to the proper network prefix — the same result Postfix would derive internally anyway. Set `invalid_cidr=remove` in `postallow.conf` to drop invalid ranges entirely, which was the documented original Postwhite/Postallow behaviour.

## Test plan

- [x] Ran against live SPF records — 1039 rules generated (same count as old build)
- [x] `ci/verify.sh` passes: no duplicates, all entries valid IP/CIDR notation
- [x] ~6 second runtime improvement (40s → 34s) from stream-based normalization