### PR TITLE
fix(scrape_yahoo): extract IPs from table cells only

### DIFF
--- a/conf/postallow.conf.in
+++ b/conf/postallow.conf.in
@@ -24,7 +24,7 @@ output_dir=@OUTPUTDIR@
 # Include additional Yahoo/Verizon/AOL outbound IPs scraped from
 # senders.yahooinc.com (on top of those already in Yahoo's SPF records).
 # Run scrape_yahoo periodically to keep the list fresh.
-include_yahoo=no
+include_yahoo=yes
 
 # Use a blocklist as well?
 # List domains to block in the blocklist_hosts section of allowlist_hosts.

--- a/postallow
+++ b/postallow
@@ -220,7 +220,11 @@ done
 if [ x"$include_yahoo" = x"yes" ] ; then
 	printf "\nIncluding scraped Yahoo! outbound hosts...\n"
 
-	cat "${yahoo_static_hosts}" >> "${tmp1}"
+	if [ ! -s "${yahoo_static_hosts}" ]; then
+		>&2 printf "WARNING: %s is empty or missing. Run scrape_yahoo to update it.\n" "${yahoo_static_hosts}"
+	else
+		cat "${yahoo_static_hosts}" >> "${tmp1}"
+	fi
 fi
 
 if [ x"$enable_blocklist" = x"yes" ] ; then

--- a/scripts/scrape_yahoo
+++ b/scripts/scrape_yahoo
@@ -65,14 +65,25 @@ else
         exit 1;
 fi
 
-# Scrape and format IPv4 addresses
-ipv4_mailers=$(echo "$content" | grep -E -o '(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/([0-9]{1,3}?)' | while read line; do echo "ip4:$line"; done)
+# Extract text content from table cells only, to avoid matching IPs in HTML/CSS/JS.
+# Uses Perl (already required for aggregateCIDR.pl) to handle minified single-line HTML.
+td_content=$(echo "$content" | perl -ne 'while (/<td[^>]*>([^<]+)<\/td>/g) { print "$1\n" }')
+
+# Scrape and format IPv4 addresses from table cells
+ipv4_mailers=$(echo "$td_content" | grep -E -o '(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/([0-9]{1,3}?)' | while read line; do echo "ip4:$line"; done)
+
+# Abort if nothing was scraped — do not overwrite the existing file with empty output
+if [ -z "$ipv4_mailers" ]; then
+    >&2 printf "ERROR: No IPv4 addresses scraped from %s\n" "$yahoo_url"
+    >&2 printf "The page structure may have changed. %s has NOT been updated.\n" "$yahoo_static_hosts"
+    exit 1
+fi
 
 # Overwrite old Yahoo! mailer list with scraped IPv4 hosts
 echo "$ipv4_mailers" | ${aggregateCIDR} --quiet --spf > "$yahoo_static_hosts"
 
-# Scrape and format IPv6 addresses
-ipv6_mailers=$(echo "$content" | grep -E -o '(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))' | while read line; do echo "ipv6:$line"; done)
+# Scrape and format IPv6 addresses from table cells
+ipv6_mailers=$(echo "$td_content" | grep -E -o '(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))' | while read line; do echo "ipv6:$line"; done)
 
 # Append IPv6 hosts to newly-created Yahoo! mailer list
 echo "$ipv6_mailers" >> "$yahoo_static_hosts"


### PR DESCRIPTION
## Summary

- The Yahoo outbound mail servers page puts all IPs in `<td>` elements, but the scraper ran its regexes against the full raw HTML, causing false positives from JavaScript and CSS. This produced bogus IPv6 entries in `yahoo_static_hosts.txt` on every run (e.g. `ipv6:::bac`, `ipv6:ea::`, `ipv6:::`).
- Fix: pre-filter the fetched HTML with a Perl one-liner to extract only `<td>` cell text before applying the IPv4/IPv6 regexes. Perl is already a dependency (required for `aggregateCIDR.pl`), and the one-liner handles minified single-line HTML correctly.
- IPv6 scraping is retained in case Yahoo adds IPv6 to their tables in future.
- Added a guard in `scrape_yahoo`: if the scrape yields no IPv4 results (e.g. page structure changed), it exits with an error and does **not** overwrite the existing file, preserving the old data.
- Added a warning in `postallow`: if `include_yahoo=yes` but the static hosts file is empty or missing, it warns on stderr and skips the append rather than silently doing nothing (or erroring on a missing file).

## Test plan

- [ ] Run `scrape_yahoo` and verify `yahoo_static_hosts.txt` contains only valid IPv4 CIDRs with no bogus `ipv6:` lines
- [ ] Confirm IP count is consistent with https://senders.yahooinc.com/outbound-mail-servers/
- [ ] Test empty-file warning: blank `yahoo_static_hosts.txt` and run `postallow` — should warn on stderr
- [ ] Test scraper guard: point `yahoo_url` at a page with no `<td>` IPs — should exit 1 without modifying the file