### PR TITLE
docs: recommend includepkgs hardening for COPR repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ for the `perl-Net-CIDR-Lite` dependency:
 ```bash
 sudo dnf install epel-release   # RHEL/AlmaLinux/Rocky only, skip on Fedora
 sudo dnf copr enable edmundlod/postallow
+```
+
+Optional: Harden this COPR repo by restricting it to only be able to pull required packages from it:
+
+```bash
+echo "includepkgs=postallow spf-tools route-summarization" \                                                                                                                       
+  | sudo tee -a /etc/yum.repos.d/edmundlod-postallow-postallow.repo                                                                                                                
+```
+
+Then install postallow:
+
+```bash
 sudo dnf install postallow
 ```
 


### PR DESCRIPTION
## Summary

- Enabling a third-party DNF/COPR repo grants it authority to provide any package to the system. Adding `includepkgs=` to the repo file restricts it to only the packages it is intended to supply.
- Splits the `dnf copr enable` and `dnf install` steps in the README to make room for the optional hardening step in between.

## Test plan

- [ ] Follow the instructions on a fresh RHEL/AlmaLinux/Fedora system and confirm `dnf install postallow` still resolves all dependencies correctly after adding `includepkgs=`
- [ ] Confirm that attempting to install an unrelated package from the COPR is blocked after the restriction is applied