### PR TITLE
feat: install.sh installs spf-tools and aggregateCIDR.pl

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# pre-commit hook: keep the README.md Table of Contents up to date.
+#
+# Activate with:   git config core.hooksPath .githooks
+#
+# Requires Node.js (npx downloads doctoc on first run).
+# If npx is not available the hook exits 0 (non-blocking) with a warning.
+
+if ! command -v npx >/dev/null 2>&1; then
+    echo "pre-commit: npx not found, skipping ToC update (install Node.js to enable)" >&2
+    exit 0
+fi
+
+make toc
+git add README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,17 @@ on:
 # ---------------------------------------------------------------------------
 # Every job follows the same sequence:
 #   1. Install postfix, DNS tools, Perl + CIDR modules, and git.
-#   2. Clone spf-tools (provides despf.sh for SPF record expansion).
-#   3. Clone route-summarization (provides aggregateCIDR.pl for CIDR aggregation).
-#   4. Create the postallow system user and output directory (via contrib/install.sh).
-#   5. Install the postallow script + config + host list + static Yahoo data.
-#   6. Write a minimal postallow.conf pointing at the correct paths.
-#   7. Configure postfix (loopback-only listener; file-based logging for containers).
-#   8. Start postfix.
-#   9. Run postallow AS THE postallow USER — this is the unprivileged half of the
+#   2. Run contrib/install.sh as root — creates the postallow user and output
+#      directory, and installs spf-tools + aggregateCIDR.pl.
+#   3. Install the postallow script + config + host list + static Yahoo data.
+#   4. Write a minimal postallow.conf pointing at the correct paths.
+#   5. Configure postfix (loopback-only listener; file-based logging for containers).
+#   6. Start postfix.
+#   7. Run postallow AS THE postallow USER — this is the unprivileged half of the
 #      privilege-separated design.  It writes the CIDR file but cannot touch postfix.
-#  10. Reload postfix AS ROOT — this is the privileged half (systemd ExecStartPost=+
+#   8. Reload postfix AS ROOT — this is the privileged half (systemd ExecStartPost=+
 #      in production; explicit root step in CI).
-#  11. Run ci/verify.sh to assert the CIDR file is present, contains no duplicate
+#   9. Run ci/verify.sh to assert the CIDR file is present, contains no duplicate
 #      entries, and contains only valid IP/CIDR notation throughout.
 #
 # DNS queries are REAL (no mocking).  The script has set -e, so a transient DNS
@@ -59,23 +58,7 @@ jobs:
             perl libnet-cidr-lite-perl libnetaddr-ip-perl \
             git
  
-      - name: Install spf-tools
-        run: |
-          sudo git clone --depth=1 \
-            https://github.com/spf-tools/spf-tools \
-            /usr/local/bin/spf-tools
-          sudo chmod +x /usr/local/bin/spf-tools/*.sh
- 
-      - name: Install aggregateCIDR.pl
-        run: |
-          sudo git clone --depth=1 \
-            https://github.com/edmundlod/route-summarization \
-            /opt/route-summarization
-          sudo install -m 755 \
-            /opt/route-summarization/aggregateCIDR.pl \
-            /usr/local/bin/aggregateCIDR.pl
- 
-      - name: Create postallow user and data directory
+      - name: Set up postallow user, data directory, and dependencies
         run: sudo sh contrib/install.sh
  
       - name: Install postallow script, host list, and static data
@@ -91,7 +74,7 @@ jobs:
         run: |
           cat > /tmp/postallow.conf <<'EOF'
           allowlist_hosts=/etc/postallow/allowlist_hosts
-          spftoolspath=/usr/local/bin/spf-tools
+          spftoolspath=/usr/local/bin
           postfixpath=/var/lib/postallow
           allowlist=postscreen_spf_allowlist.cidr
           blocklist=postscreen_spf_blocklist.cidr
@@ -151,23 +134,7 @@ jobs:
             perl libnet-cidr-lite-perl libnetaddr-ip-perl \
             git
 
-      - name: Install spf-tools
-        run: |
-          git clone --depth=1 \
-            https://github.com/spf-tools/spf-tools \
-            /usr/local/bin/spf-tools
-          chmod +x /usr/local/bin/spf-tools/*.sh
-
-      - name: Install aggregateCIDR.pl
-        run: |
-          git clone --depth=1 \
-            https://github.com/edmundlod/route-summarization \
-            /opt/route-summarization
-          install -m 755 \
-            /opt/route-summarization/aggregateCIDR.pl \
-            /usr/local/bin/aggregateCIDR.pl
-
-      - name: Create postallow user and data directory
+      - name: Set up postallow user, data directory, and dependencies
         run: sh contrib/install.sh
 
       - name: Install postallow script, host list, and static data
@@ -183,7 +150,7 @@ jobs:
         run: |
           cat > /etc/postallow/postallow.conf <<'EOF'
           allowlist_hosts=/etc/postallow/allowlist_hosts
-          spftoolspath=/usr/local/bin/spf-tools
+          spftoolspath=/usr/local/bin
           postfixpath=/var/lib/postallow
           allowlist=postscreen_spf_allowlist.cidr
           blocklist=postscreen_spf_blocklist.cidr
@@ -243,23 +210,7 @@ jobs:
             git \
             procps-ng
 
-      - name: Install spf-tools
-        run: |
-          git clone --depth=1 \
-            https://github.com/spf-tools/spf-tools \
-            /usr/local/bin/spf-tools
-          chmod +x /usr/local/bin/spf-tools/*.sh
-
-      - name: Install aggregateCIDR.pl
-        run: |
-          git clone --depth=1 \
-            https://github.com/edmundlod/route-summarization \
-            /opt/route-summarization
-          install -m 755 \
-            /opt/route-summarization/aggregateCIDR.pl \
-            /usr/local/bin/aggregateCIDR.pl
-
-      - name: Create postallow user and data directory
+      - name: Set up postallow user, data directory, and dependencies
         run: sh contrib/install.sh
 
       - name: Install postallow script, host list, and static data
@@ -275,7 +226,7 @@ jobs:
         run: |
           cat > /etc/postallow/postallow.conf <<'EOF'
           allowlist_hosts=/etc/postallow/allowlist_hosts
-          spftoolspath=/usr/local/bin/spf-tools
+          spftoolspath=/usr/local/bin
           postfixpath=/var/lib/postallow
           allowlist=postscreen_spf_allowlist.cidr
           blocklist=postscreen_spf_blocklist.cidr
@@ -331,23 +282,7 @@ jobs:
             git \
             procps-ng
 
-      - name: Install spf-tools
-        run: |
-          git clone --depth=1 \
-            https://github.com/spf-tools/spf-tools \
-            /usr/local/bin/spf-tools
-          chmod +x /usr/local/bin/spf-tools/*.sh
-
-      - name: Install aggregateCIDR.pl
-        run: |
-          git clone --depth=1 \
-            https://github.com/edmundlod/route-summarization \
-            /opt/route-summarization
-          install -m 755 \
-            /opt/route-summarization/aggregateCIDR.pl \
-            /usr/local/bin/aggregateCIDR.pl
-
-      - name: Create postallow user and data directory
+      - name: Set up postallow user, data directory, and dependencies
         run: sh contrib/install.sh
 
       - name: Install postallow script, host list, and static data
@@ -363,7 +298,7 @@ jobs:
         run: |
           cat > /etc/postallow/postallow.conf <<'EOF'
           allowlist_hosts=/etc/postallow/allowlist_hosts
-          spftoolspath=/usr/local/bin/spf-tools
+          spftoolspath=/usr/local/bin
           postfixpath=/var/lib/postallow
           allowlist=postscreen_spf_allowlist.cidr
           blocklist=postscreen_spf_blocklist.cidr
@@ -438,22 +373,9 @@ jobs:
           run: |
             set -e
             
-            # --- Install spf-tools ---
-            git clone --depth=1 \
-              https://github.com/spf-tools/spf-tools \
-              /usr/local/bin/spf-tools
-            chmod +x /usr/local/bin/spf-tools/*.sh
-
-            # --- Install aggregateCIDR.pl ---
-            git clone --depth=1 \
-              https://github.com/edmundlod/route-summarization \
-              /opt/route-summarization
-            install -m 755 \
-              /opt/route-summarization/aggregateCIDR.pl \
-              /usr/local/bin/aggregateCIDR.pl
-
-            # --- Create postallow user and data directory ---
+            # --- Set up postallow user, data directory, and dependencies ---
             # contrib/install.sh detects FreeBSD via uname and uses pw(8).
+            # It also installs spf-tools and aggregateCIDR.pl.
             sh contrib/install.sh
 
             # --- Install postallow script, host list, and static data ---
@@ -468,7 +390,7 @@ jobs:
             # --- Write postallow.conf (FreeBSD paths) ---
             cat > /usr/local/etc/postallow/postallow.conf <<'CONF'
             allowlist_hosts=/usr/local/etc/postallow/allowlist_hosts
-            spftoolspath=/usr/local/bin/spf-tools
+            spftoolspath=/usr/local/bin
             postfixpath=/var/db/postallow
             allowlist=postscreen_spf_allowlist.cidr
             blocklist=postscreen_spf_blocklist.cidr

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,14 @@ COMPRESS_MAN ?= auto
 GZIP         ?= gzip
 GZIP_FLAGS   ?= -9
 
-.PHONY: install uninstall help
+.PHONY: install uninstall toc help
+
+# Regenerate the Table of Contents in README.md.
+# Requires Node.js (uses npx to download doctoc on first run).
+# Activate the pre-commit hook to run this automatically:
+#   git config core.hooksPath .githooks
+toc:
+	npx --yes doctoc --github --title '## Contents' README.md
 
 help:
 	@echo "Targets:  install, uninstall, help"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,37 @@ A script for generating a Postscreen allowlist (and optionally a blocklist) base
 | AlmaLinux 10 | [![AlmaLinux 10](https://github.com/edmundlod/postallow/actions/workflows/ci.yml/badge.svg?job=almalinux-10)](https://github.com/edmundlod/postallow/actions/workflows/ci.yml) |
 | FreeBSD 15 | [![FreeBSD 15](https://github.com/edmundlod/postallow/actions/workflows/ci.yml/badge.svg?job=freebsd-15)](https://github.com/edmundlod/postallow/actions/workflows/ci.yml) |
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Contents
+
+- [Why Postallow?](#why-postallow)
+- [Warning about Blocklisting](#warning-about-blocklisting)
+- [Requirements](#requirements)
+- [Usage](#usage)
+- [Installation](#installation)
+  - [via apt](#via-apt)
+  - [via dnf (AlmaLinux 10 / RHEL 10 / Fedora / OpenSUSE)](#via-dnf-almalinux-10--rhel-10--fedora--opensuse)
+  - [Manual installation](#manual-installation)
+    - [1. Create the postallow user, output directory, and install dependencies](#1-create-the-postallow-user-output-directory-and-install-dependencies)
+    - [2. Install Postallow](#2-install-postallow)
+  - [Configure Postallow](#configure-postallow)
+  - [Configure Postfix](#configure-postfix)
+  - [Enable the init service](#enable-the-init-service)
+  - [Yahoo! Hosts](#yahoo-hosts)
+- [Options](#options)
+  - [Custom Hosts](#custom-hosts)
+  - [Hosts that Don't Publish their Outbound Mailers via SPF Records](#hosts-that-dont-publish-their-outbound-mailers-via-spf-records)
+  - [Yahoo! Hosts](#yahoo-hosts-1)
+  - [Blocklisting](#blocklisting)
+  - [Invalid hosts](#invalid-hosts)
+- [Credits](#credits)
+- [More Info](#more-info)
+- [Suggestions for Additional Mailers](#suggestions-for-additional-mailers)
+- [Disclaimer](#disclaimer)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Why Postallow?
 Postallow uses the published SPF records from domains of known webmailers, social networks, ecommerce providers, and compliant bulk senders to generate a list of outbound mailer IP addresses and CIDR ranges to create a allowlist (and optionally a blocklist) for Postfix's Postscreen.
 
@@ -22,12 +53,8 @@ If all of the allowlist mailers are selected when Postallow runs, the resulting 
 By default, Postallow has blocklisting turned off. Most users will not need to ever turn it on, but it's there if you *really* believe you need it. If you choose to enable it, make sure you understand the implications of blocklisting IP addresses based on their hostnames and associated mailers, and re-run Postallow often via cron to make sure you're not inadvertently blocking legitimate senders.
 
 # Requirements
-Postallow runs as a shell script (```/bin/sh```) and relies on two scripts from the <a target="_blank"
-href="https://github.com/spf-tools/spf-tools">SPF-Tools</a> project and another script by <a target="_blank" href="https://github.com/nabbi/route-summarization/">Nabbi</a> to help recursively query SPF records.
-
-If you use `apt` or `yum`/`dnf` or the AUR to install software, there are 3rd party repo's and packages available (see below).
-
-In all other events, you will need to install `spf-tools`, `route-summarization`, and `postallow` manually. Instructions are further down below.
+Postallow runs as a shell script (```/bin/sh```) and relies on scripts from the <a target="_blank"
+href="https://github.com/spf-tools/spf-tools">SPF-Tools</a> project (**despf.sh**, **normalize.sh**) to help recursively query and normalise SPF records. Unless you install via `apt` or `yum`/`dnf` (see below), use `contrib/install.sh` or the manual steps in the [Manual installation](#manual-installation) section to install them, then confirm the `spftoolspath` value in `postallow.conf`.
 
 In order to run `postallow` you will need:
 
@@ -92,58 +119,48 @@ Then continue with [Configure Postallow](#configure-postallow).
 
 ## Manual installation
 
-### Helper script
+### 1. Create the postallow user, output directory, and install dependencies
 
-A helper script is provided for common platforms:
+A helper script is provided for common platforms (requires **git**):
 
     sudo contrib/install.sh
 
-This creates the `postallow` system user and the output directory with correct ownership, and installs the dependencies.
+This creates the `postallow` system user and the output directory with correct ownership, and installs [spf-tools](https://github.com/spf-tools/spf-tools) and [aggregateCIDR.pl](https://github.com/edmundlod/route-summarization) into `/usr/local/bin/`. OS packagers should handle all of this in their own package lifecycle hooks instead.
 
-OS packagers should handle this in their package lifecycle hooks instead.
+If you prefer to do it manually, or are on an unsupported platform, perform each step in turn:
 
-### Manual installation
+**Create the `postallow` user:**
 
-#### 1. Create the postallow user and output directory
+| Platform | Command |
+|---|---|
+| Linux | `useradd --system --no-create-home --shell /usr/sbin/nologin postallow` |
+| FreeBSD | `pw useradd -n postallow -d /nonexistent -s /usr/sbin/nologin -w no` |
+| OpenBSD | `useradd -r 1..999 -d /nonexistent -s /sbin/nologin postallow` |
+| NetBSD | `useradd -r -d /nonexistent -s /sbin/nologin postallow` |
 
-If you prefer to do it manually, or are on an unsupported platform:
+**Create the output directory** owned by `postallow` with mode 755:
 
-| Platform | User creation | Output directory |
-|---|---|---|
-| Linux | `useradd --system --no-create-home --shell /usr/sbin/nologin postallow` | `/var/lib/postallow` |
-| FreeBSD | `pw useradd -n postallow -d /nonexistent -s /usr/sbin/nologin -w no` | `/var/db/postallow` |
-| OpenBSD | `useradd -r 1..999 -d /nonexistent -s /sbin/nologin postallow` | `/var/postallow` |
-| NetBSD | `useradd -r -d /nonexistent -s /sbin/nologin postallow` | `/var/db/postallow` |
-
-Create the directory owned by `postallow` with mode 755:
+| Platform | Directory |
+|---|---|
+| Linux | `/var/lib/postallow` |
+| FreeBSD / NetBSD | `/var/db/postallow` |
+| OpenBSD | `/var/postallow` |
 
     install -d -o postallow -m 755 /var/lib/postallow   # adjust path for your platform
 
-### 2. Install spf-tools (dependency for Postallow)
+**Install spf-tools:**
 
-We only need the shell scripts from `spf-tools`, nothing else. Download to a temporary directory and install the shell scripts to `/usr/local/bin`.
+    git clone --depth=1 https://github.com/spf-tools/spf-tools /tmp/spf-tools
+    for f in /tmp/spf-tools/*.sh; do install -m 755 "$f" /usr/local/bin/; done
+    rm -rf /tmp/spf-tools
 
-```bash
-TMPDIR=$(mktemp -d)
-curl -sL https://github.com/spf-tools/spf-tools/archive/refs/tags/v2.3.tar.gz \
-  | tar -xz --strip-components=1 -C "$TMPDIR" --wildcards 'spf-tools-2.3/*.sh'
-sudo install -m 755 "$TMPDIR"/*.sh /usr/local/bin/
-rm -rf "$TMPDIR"
-```
+**Install aggregateCIDR.pl:**
 
-### 3. Install route-summarization (dependency for Postallow)
+    git clone --depth=1 https://github.com/edmundlod/route-summarization /tmp/route-summarization
+    install -m 755 /tmp/route-summarization/aggregateCIDR.pl /usr/local/bin/aggregateCIDR.pl
+    rm -rf /tmp/route-summarization
 
-We only need the Perl script from `route-summarization`, nothing else. Download to a temporary directory and install the script to `/usr/local/bin`.
-
-```bash
-TMPDIR=$(mktemp -d)
-curl -sL https://raw.githubusercontent.com/nabbi/route-summarization/master/aggregateCIDR.pl \
-  -o "$TMPDIR/aggregateCIDR.pl"
-sudo install -m 755 "$TMPDIR/aggregateCIDR.pl" /usr/local/bin/
-rm -rf "$TMPDIR"
-```
-
-### 4. Install Postallow
+### 2. Install Postallow
 
     make install
 

--- a/conf/postallow.conf.in
+++ b/conf/postallow.conf.in
@@ -10,7 +10,7 @@ allowlist_hosts=@DATADIR@/allowlist_hosts
 custom_hosts_file=@SYSCONFDIR@/postallow/custom_hosts
 
 # Location of spf-tools
-spftoolspath=@BINDIR@/spf-tools
+spftoolspath=/usr/local/bin
 
 # Directory where the generated CIDR files are written.
 # Postallow writes these files as the postallow user (world-readable, mode 644).

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -3,13 +3,13 @@
 # Postallow install helper
 # https://github.com/edmundlod/postallow
 #
-# Creates the postallow system user and output directory for common platforms.
-# It then pulls the dependencies `spf-tools` and `route-summarization` from
-# github.com and installs them with correct permissions in `/usr/local/bin`.
+# Creates the postallow system user and output directory, and installs the two
+# required dependencies (spf-tools scripts and aggregateCIDR.pl) into /usr/local/bin/.
 #
-# This is a convenience script - OS packagers should handle this in their own
-# package lifecycle hooks instead.
+# This is a convenience script for manual installs on common platforms.
+# OS packagers should handle all of this in their own package lifecycle hooks.
 #
+# Requires: git
 # Run as root.
 
 set -e
@@ -75,23 +75,73 @@ else
     echo "Created ${DATADIR} owned by ${POSTALLOW_USER}."
 fi
 
-# Install the dependencies, `spf-tools` and `route-summarization`
-# to `/usr/local/bin`
 
-TMPDIR=$(mktemp -d)
-curl -sL https://github.com/spf-tools/spf-tools/archive/refs/tags/v2.3.tar.gz \
-  | tar -xz --strip-components=1 -C "$TMPDIR" --wildcards 'spf-tools-2.3/*.sh'
-sudo install -m 755 "$TMPDIR"/*.sh /usr/local/bin/
-rm -rf "$TMPDIR"
+# --- Install spf-tools ---
 
-TMPDIR=$(mktemp -d)
-curl -sL https://raw.githubusercontent.com/nabbi/route-summarization/master/aggregateCIDR.pl \
-  -o "$TMPDIR/aggregateCIDR.pl"
-sudo install -m 755 "$TMPDIR/aggregateCIDR.pl" /usr/local/bin/
-rm -rf "$TMPDIR"
+_install_spf=true
+if command -v despf.sh >/dev/null 2>&1; then
+    if [ -t 0 ]; then
+        printf 'spf-tools is already installed. Reinstall to update? [y/N] '
+        read -r _ans
+        case "${_ans}" in
+            [Yy]*) _install_spf=true ;;
+            *) _install_spf=false; echo "Leaving spf-tools as-is." ;;
+        esac
+    else
+        echo "spf-tools already installed (non-interactive run, leaving as-is)."
+        _install_spf=false
+    fi
+fi
+
+if [ "${_install_spf}" = true ]; then
+    if ! command -v git >/dev/null 2>&1; then
+        echo "Error: git is required to install spf-tools. Please install git first." >&2
+        exit 1
+    fi
+    _tmpdir=$(mktemp -d)
+    git clone --depth=1 https://github.com/spf-tools/spf-tools "${_tmpdir}/spf-tools"
+    for _f in "${_tmpdir}/spf-tools"/*.sh; do
+        install -m 755 "${_f}" /usr/local/bin/
+    done
+    rm -rf "${_tmpdir}"
+    echo "Installed spf-tools scripts to /usr/local/bin/."
+fi
+
+# --- Install aggregateCIDR.pl ---
+
+AGGREGATE_BIN="/usr/local/bin/aggregateCIDR.pl"
+
+_install_agg=true
+if [ -f "${AGGREGATE_BIN}" ]; then
+    if [ -t 0 ]; then
+        printf 'aggregateCIDR.pl is already installed. Reinstall to update? [y/N] '
+        read -r _ans
+        case "${_ans}" in
+            [Yy]*) _install_agg=true ;;
+            *) _install_agg=false; echo "Leaving aggregateCIDR.pl as-is." ;;
+        esac
+    else
+        echo "aggregateCIDR.pl already installed (non-interactive run, leaving as-is)."
+        _install_agg=false
+    fi
+fi
+
+if [ "${_install_agg}" = true ]; then
+    if ! command -v git >/dev/null 2>&1; then
+        echo "Error: git is required to install route-summarization. Please install git first." >&2
+        exit 1
+    fi
+    _tmpdir=$(mktemp -d)
+    git clone --depth=1 \
+        https://github.com/edmundlod/route-summarization "${_tmpdir}/route-summarization"
+    install -m 755 "${_tmpdir}/route-summarization/aggregateCIDR.pl" "${AGGREGATE_BIN}"
+    rm -rf "${_tmpdir}"
+    echo "Installed aggregateCIDR.pl to ${AGGREGATE_BIN}."
+fi
 
 echo ""
 echo "Done. Next steps:"
-echo "  1. Set postfixpath=${DATADIR} in postallow.conf"
-echo "  2. Update Postfix main.cf postscreen_access_list to reference ${DATADIR}"
-echo "  3. Install the appropriate init service from contrib/"
+echo "  1. Run: make install"
+echo "  2. Set output_dir=${DATADIR} in postallow.conf"
+echo "  3. Update Postfix main.cf postscreen_access_list to reference ${DATADIR}"
+echo "  4. Enable the appropriate init service from contrib/"


### PR DESCRIPTION
## Summary

- `contrib/install.sh` now installs both runtime dependencies in addition to creating the `postallow` user and output directory
- spf-tools scripts cloned to a tmpdir, installed individually with `install -m 755` into `/usr/local/bin/` — no subdirectory, no wildcard `chmod`, no leftover `.git`/README
- `aggregateCIDR.pl` uses the same tmpdir pattern
- Both prompt `Reinstall to update? [y/N]` when already present and running interactively; skip silently when non-interactive (CI)
- `spftoolspath` updated to `/usr/local/bin` everywhere (`ci.yml`, `conf/postallow.conf.in`)
- CI simplified: redundant separate dep-install steps removed from all four Linux jobs and the FreeBSD inline block
- README manual installation section expanded with split tables and explicit dep-install steps; ToC added with doctoc markers
- `make toc` target added; `.githooks/pre-commit` auto-updates ToC on commit if `npx` is available (activate with `git config core.hooksPath .githooks`)

## Test plan

- [ ] Trigger CI on this PR and confirm all five jobs pass
- [ ] Manually verify `sudo contrib/install.sh` on a clean Linux system installs spf-tools scripts and `aggregateCIDR.pl` into `/usr/local/bin/`
- [ ] Re-run `sudo contrib/install.sh` and confirm the reinstall prompt appears
- [ ] Confirm `make toc` updates the ToC in `README.md`