### PR TITLE
fix: correct tab indentation in Makefile AppArmor block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,18 +138,18 @@ install:
 	# installed as documentation rather than an executable tool.
 	install -m 644 scripts/query_mailer_ovh $(DESTDIR)$(DOCDIR)/query_mailer_ovh.example
 
-    # --- AppArmor profile (Linux only, if AppArmor is available) ---
-    @case "$$(uname -s)" in \
-    Linux) \
-            if command -v aa-status >/dev/null 2>&1 || [ -d /etc/apparmor.d ]; then \
-                    echo "# apparmor"; \
-                    install -d -m 755 $(DESTDIR)/etc/apparmor.d; \
-                    install -m 644 contrib/apparmor/usr.bin.postallow \
-                            $(DESTDIR)/etc/apparmor.d/usr.bin.postallow; \
-                    echo "  installed: /etc/apparmor.d/usr.bin.postallow"; \
-            fi \
-            ;; \
-    esac
+	# --- AppArmor profile (Linux only, if AppArmor is available) ---
+	@case "$$(uname -s)" in \
+	Linux) \
+		if command -v aa-status >/dev/null 2>&1 || [ -d /etc/apparmor.d ]; then \
+			echo "# apparmor"; \
+			install -d -m 755 $(DESTDIR)/etc/apparmor.d; \
+			install -m 644 contrib/apparmor/usr.bin.postallow \
+				$(DESTDIR)/etc/apparmor.d/usr.bin.postallow; \
+			echo "  installed: /etc/apparmor.d/usr.bin.postallow"; \
+		fi \
+		;; \
+	esac
 
 	# --- init service units – platform detected at install time ---
 	@case "$$(uname -s)" in \


### PR DESCRIPTION
The AppArmor recipe block (lines 141–152) was indented with spaces instead of tabs, causing `make` to abort with `missing separator` on both the deb and rpm build workflows triggered by the v4.5.0 tag.

**Root cause:** GNU make requires a literal tab character at the start of every recipe line. The surrounding blocks all used tabs correctly; this block was the odd one out.

**Fix:** Replace the 4-space indent with tabs throughout the block, consistent with the rest of the Makefile.