### PR TITLE
ci: upgrade softprops/action-gh-release v2 → v3

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - 'v*'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   build-deb:
     runs-on: ubuntu-latest
@@ -36,7 +33,7 @@ jobs:
         run: echo "filename=$(ls dist/*.deb | xargs basename)" >> $GITHUB_OUTPUT
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*.deb
 

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - 'v*'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   build-rpm:
     runs-on: ubuntu-latest
@@ -51,7 +48,7 @@ jobs:
         run: echo "filename=$(ls dist/*.rpm | xargs basename)" >> $GITHUB_OUTPUT
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*.rpm
 


### PR DESCRIPTION
v3 targets Node.js 24 natively, resolving the deprecation warning seen in the v4.5.0 build runs.

Also removes the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var from both build workflows — it was only there as a workaround for the v2 Node.js 20 issue and is no longer needed.