### PR TITLE
fix: pass codename in apt dispatch payload

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -28,9 +28,11 @@ jobs:
           mkdir dist
           mv ../*.deb dist/
 
-      - name: Get .deb filename
+      - name: Get .deb filename and distribution codename
         id: deb
-        run: echo "filename=$(ls dist/*.deb | xargs basename)" >> $GITHUB_OUTPUT
+        run: |
+          echo "filename=$(ls dist/*.deb | xargs basename)" >> $GITHUB_OUTPUT
+          echo "codename=$(dpkg-parsechangelog --show-field Distribution)" >> $GITHUB_OUTPUT
 
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v3
@@ -42,9 +44,9 @@ jobs:
           for deb in dist/*.deb; do
             pkg=$(basename "$deb")
             url="https://github.com/edmundlod/postallow/releases/download/${{ github.ref_name }}/${pkg}"
-            curl -s -X POST \
+            curl -sf -X POST \
               -H "Authorization: Bearer ${{ secrets.REPO_DISPATCH_APT_AND_RPM }}" \
               -H "Accept: application/vnd.github+json" \
               https://api.github.com/repos/edmundlod/apt/dispatches \
-              -d "{\"event_type\":\"package-built\",\"client_payload\":{\"deb_url\":\"${url}\",\"package\":\"${pkg}\"}}"
+              -d "{\"event_type\":\"package-built\",\"client_payload\":{\"deb_url\":\"${url}\",\"package\":\"${pkg}\",\"codename\":\"${{ steps.deb.outputs.codename }}\"}}"
           done


### PR DESCRIPTION
The apt dispatch payload was missing the `codename` field, causing reprepro to fail with `Cannot find definition of distribution ''`. The job still reported success because `curl -s` suppressed the error output.

**Root cause:** `build-deb.yml` sent `deb_url` and `package` but never `codename`. The apt repo workflow passes that field straight to `reprepro includedeb $CODENAME`, which requires it.

**Fix:**
- Extract the codename from `debian/changelog` via `dpkg-parsechangelog --show-field Distribution` (already available from the installed build deps) and add it as `client_payload.codename` in the dispatch payload.
- Add `-f` to the `curl` call so a non-2xx response actually fails the job instead of silently passing.